### PR TITLE
fix[modal] : fix #63

### DIFF
--- a/examples/vanilla/dialog/main.ts
+++ b/examples/vanilla/dialog/main.ts
@@ -1,4 +1,4 @@
-import { Modal, ModalOptions } from "@flexilla/modal"
+import { Modal, ModalOptions } from "@flexilla/flexilla"
 import "./../main"
 
 new Modal("[data-modal-test-1]")

--- a/packages/modal/src/helpers.ts
+++ b/packages/modal/src/helpers.ts
@@ -29,7 +29,7 @@ const setBodyScrollable = (enableStackedModals_: boolean, allowBodyScroll_: bool
 const initModal = (modalElement: HTMLElement, triggerButton: HTMLElement | null, options: ModalOptions) => {
     if (!(modalElement instanceof HTMLElement)) throw new Error("Modal Element must be a valid element");
 
-    const { animateContent, allowBodyScroll, preventCloseModal, overlayClass, onShow, onHide, onToggle, enableStackedModals } = options;
+    const { animateContent, allowBodyScroll, preventCloseModal, overlayClass, onShow, onHide, onToggle, beforeHide, enableStackedModals } = options;
 
     const allowBodyScroll_ = allowBodyScroll || modalElement.hasAttribute("data-allow-body-scroll") && modalElement.getAttribute("data-allow-body-scroll") !== "false"
     const preventCloseModal_ = preventCloseModal || modalElement.hasAttribute("data-prevent-close-modal") && modalElement.getAttribute("data-prevent-close-modal") !== "false"
@@ -111,6 +111,7 @@ const initModal = (modalElement: HTMLElement, triggerButton: HTMLElement | null,
 
 
     const hideModal = () => {
+        beforeHide?.()
         const hideModal_ = () => {
             toggleModalState(modalElement, modalContent, "close");
             setBodyScrollable(enableStackedModals_, allowBodyScroll_, modalElement)
@@ -125,7 +126,7 @@ const initModal = (modalElement: HTMLElement, triggerButton: HTMLElement | null,
                 { once: true }
             );
         }
-        if ((animateContent?.exitAnimation && animateContent.exitAnimation !== "")|| animationExit !== "") {
+        if ((animateContent?.exitAnimation && animateContent.exitAnimation !== "") || animationExit !== "") {
             const exitAnimation_ = animateContent ? animateContent.exitAnimation || "" : animationExit;
             modalContent.setAttribute("data-state", "close");
             modalContent.style.setProperty("--un-modal-animation", exitAnimation_);
@@ -151,7 +152,10 @@ const initModal = (modalElement: HTMLElement, triggerButton: HTMLElement | null,
         if (triggerButton instanceof HTMLElement) triggerButton.addEventListener("click", showModal);
         if (closeButtons.length > 0) {
             for (const closeButton of closeButtons) {
-                closeButton.addEventListener("click", hideModal);
+                closeButton.addEventListener("click", e => {
+                    e.preventDefault()
+                    hideModal()
+                });
             }
         }
     }

--- a/packages/modal/src/types.ts
+++ b/packages/modal/src/types.ts
@@ -16,6 +16,7 @@ export type ModalOptions = {
     preventCloseModal?: boolean;
     allowBodyScroll?: boolean;
     enableStackedModals?: boolean
+    beforeHide?:()=>void;
     onShow?: () => void;
     onHide?: () => void;
     onToggle?: ({ isHidden }: { isHidden: boolean }) => void


### PR DESCRIPTION
Prevent page from reloading when the closing button is inside a form element, also can add an action before closing a modal